### PR TITLE
Speedup + Accuracy 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ __pycache__
 test_docs/
 *.pyc
 .coverage
-build
+build/
+*.pdf

--- a/README.md
+++ b/README.md
@@ -40,3 +40,7 @@ Installation
 `pip install nose`
 Running tests
 `nosetests`
+
+##### OCR methodology
+Documents are converted to gray PNGs with a DPI of 300 using [Ghostscript](http://www.ghostscript.com/) and then OCRed with [Tesseract](https://code.google.com/p/tesseract-ocr/).
+Settings for OCR adapted from [OPTIMAL IMAGE CONVERSION SETTINGS FOR TESSERACT OCR](https://mazira.com/blog/optimal-image-conversion-settings-tesseract-ocr) and [The Free Law Project's Courtlistener](https://github.com/freelawproject/courtlistener).

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -27,7 +27,7 @@ def delete_files():
         'excel_spreadsheet',
         'record_some_text'
     ]
-    extensions = ['_metadata.json', '.tiff', '.txt']
+    extensions = ['_metadata.json', '.png', '.txt']
     for item_path in file_iterator(items_to_delete, extensions):
         if os.path.isfile(item_path):
             os.remove(item_path)
@@ -82,7 +82,7 @@ class TestTextExtraction(TestCase):
             extractor.extract()
             self.assertTrue(os.path.isfile(extractor.root + '.txt'))
             self.assertTrue(os.path.isfile(extractor.root + '_metadata.json'))
-            self.assertFalse(os.path.isfile(extractor.root + '.tiff'))
+            self.assertFalse(os.path.isfile(extractor.root + '.png'))
 
 
 class TestPDFTextExtraction(TestCase):
@@ -149,14 +149,14 @@ class TestPDFTextExtraction(TestCase):
         self.assertTrue(
             os.path.isfile(LOCAL_PATH + '/fixtures/record_text.txt'))
         self.assertFalse(
-            os.path.isfile(LOCAL_PATH + '/fixtures/record_text.tiff'))
+            os.path.isfile(LOCAL_PATH + '/fixtures/record_text.png'))
         self.assertTrue(
             os.path.isfile(LOCAL_PATH + '/fixtures/record_text_metadata.json'))
 
         self.assertTrue(
             os.path.isfile(LOCAL_PATH + '/fixtures/record_no_text.txt'))
         self.assertTrue(
-            os.path.isfile(LOCAL_PATH + '/fixtures/record_no_text.tiff'))
+            os.path.isfile(LOCAL_PATH + '/fixtures/record_no_text.png'))
         self.assertTrue(os.path.isfile(
             LOCAL_PATH + '/fixtures/record_no_text_metadata.json'))
 
@@ -189,13 +189,13 @@ class Testtextextractor(TestCase):
 
         # Check that only doc with no text used OCR
         self.assertTrue(
-            os.path.isfile(LOCAL_PATH + '/fixtures/record_no_text.tiff'))
+            os.path.isfile(LOCAL_PATH + '/fixtures/record_no_text.png'))
         self.assertTrue(
-            os.path.isfile(LOCAL_PATH + '/fixtures/record_some_text.tiff'))
+            os.path.isfile(LOCAL_PATH + '/fixtures/record_some_text.png'))
         self.assertFalse(
-            os.path.isfile(LOCAL_PATH + '/fixtures/record_text.tiff'))
+            os.path.isfile(LOCAL_PATH + '/fixtures/record_text.png'))
         self.assertFalse(
-            os.path.isfile(LOCAL_PATH + '/fixtures/excel_spreadsheet.tiff'))
+            os.path.isfile(LOCAL_PATH + '/fixtures/excel_spreadsheet.png'))
 
 if __name__ == '__main__':
     main()

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -11,10 +11,9 @@ def file_iterator(base_files, extensions=['']):
     """
     Iterates through a list of base_files with each extension given
     """
-    local_path = os.path.dirname(os.path.realpath(__file__))
     for base_file in base_files:
         for extension in extensions:
-            yield local_path + '/fixtures/' + base_file + extension
+            yield os.path.join(LOCAL_PATH, 'fixtures', base_file + extension)
 
 
 def delete_files():
@@ -27,7 +26,7 @@ def delete_files():
         'excel_spreadsheet',
         'record_some_text'
     ]
-    extensions = ['_metadata.json', '.png', '.txt']
+    extensions = ['_metadata.json', '_001.png', '.txt']
     for item_path in file_iterator(items_to_delete, extensions):
         if os.path.isfile(item_path):
             os.remove(item_path)
@@ -45,25 +44,24 @@ class TestTextExtraction(TestCase):
         """
         Check if meta data is properly created
         """
-
         extractor = TextExtraction(
-            doc_path=LOCAL_PATH + '/fixtures/record_text.pdf')
+            doc_path=os.path.join(LOCAL_PATH, 'fixtures/record_text.pdf'))
         extractor.extract_metadata()
-        self.assertTrue(
-            os.path.isfile(LOCAL_PATH + '/fixtures/record_text_metadata.json'))
+        self.assertTrue(os.path.isfile(
+            os.path.join(LOCAL_PATH, 'fixtures/record_text_metadata.json')))
 
     def test_doc_to_text(self):
         """
         Check if document text is properly extracted, when possible
         """
         extractor = TextExtraction(
-            doc_path=LOCAL_PATH + '/fixtures/record_text.pdf')
+            doc_path=os.path.join(LOCAL_PATH, 'fixtures/record_text.pdf'))
         doc = extractor.doc_to_text()
         self.assertTrue(
             'Cupcake ipsum dolor sit' in doc.stdout.read().decode('utf-8'))
 
         extractor = TextExtraction(
-            doc_path=LOCAL_PATH + '/fixtures/record_no_text.pdf')
+            doc_path=os.path.join(LOCAL_PATH, 'fixtures/record_no_text.pdf'))
         doc = extractor.doc_to_text()
         self.assertEqual(doc.stdout.read().decode('utf-8').strip('\n'), '')
 
@@ -82,7 +80,7 @@ class TestTextExtraction(TestCase):
             extractor.extract()
             self.assertTrue(os.path.isfile(extractor.root + '.txt'))
             self.assertTrue(os.path.isfile(extractor.root + '_metadata.json'))
-            self.assertFalse(os.path.isfile(extractor.root + '.png'))
+            self.assertFalse(os.path.isfile(extractor.root + '_001.png'))
 
 
 class TestPDFTextExtraction(TestCase):
@@ -112,11 +110,11 @@ class TestPDFTextExtraction(TestCase):
         Check if check_for_text returns True when document contains text
         """
 
-        doc_path = "tests/fixtures/record_text.pdf"
+        doc_path = os.path.join(LOCAL_PATH, "fixtures/record_text.pdf")
         extractor = PDFTextExtraction(doc_path=doc_path)
         self.assertTrue(extractor.has_text())
 
-        doc_path = "tests/fixtures/record_no_text.pdf"
+        doc_path = os.path.join(LOCAL_PATH, "fixtures/record_no_text.pdf")
         extractor = PDFTextExtraction(doc_path=doc_path)
         self.assertFalse(extractor.has_text())
 
@@ -125,11 +123,11 @@ class TestPDFTextExtraction(TestCase):
         Check if pdf docs can be converted to images and then to text
         """
         extractor = PDFTextExtraction(
-            doc_path=LOCAL_PATH + '/fixtures/record_no_text.pdf')
+            doc_path=os.path.join(LOCAL_PATH, 'fixtures/record_no_text.pdf'))
         extractor.pdf_to_img()
         extractor.img_to_text()
-        self.assertTrue(
-            os.path.isfile(LOCAL_PATH + '/fixtures/record_no_text.txt'))
+        self.assertTrue(os.path.isfile(
+            os.path.join(LOCAL_PATH, 'fixtures/record_no_text.pdf')))
 
     def test_extract(self):
         """
@@ -138,27 +136,27 @@ class TestPDFTextExtraction(TestCase):
         """
         # Run extraction
         extractor = PDFTextExtraction(
-            doc_path=LOCAL_PATH + '/fixtures/record_text.pdf')
+            doc_path=os.path.join(LOCAL_PATH, 'fixtures/record_text.pdf'))
         extractor.extract()
 
         extractor = PDFTextExtraction(
-            doc_path=LOCAL_PATH + '/fixtures/record_no_text.pdf')
+            doc_path=os.path.join(LOCAL_PATH, 'fixtures/record_no_text.pdf'))
         extractor.extract()
 
         # Check for image file, when no text
-        self.assertTrue(
-            os.path.isfile(LOCAL_PATH + '/fixtures/record_text.txt'))
-        self.assertFalse(
-            os.path.isfile(LOCAL_PATH + '/fixtures/record_text.png'))
-        self.assertTrue(
-            os.path.isfile(LOCAL_PATH + '/fixtures/record_text_metadata.json'))
-
-        self.assertTrue(
-            os.path.isfile(LOCAL_PATH + '/fixtures/record_no_text.txt'))
-        self.assertTrue(
-            os.path.isfile(LOCAL_PATH + '/fixtures/record_no_text.png'))
         self.assertTrue(os.path.isfile(
-            LOCAL_PATH + '/fixtures/record_no_text_metadata.json'))
+            os.path.join(LOCAL_PATH, 'fixtures/record_text.txt')))
+        self.assertFalse(os.path.isfile(
+            os.path.join(LOCAL_PATH, 'fixtures/record_text_001.png')))
+        self.assertTrue(os.path.isfile(
+            os.path.join(LOCAL_PATH, 'fixtures/record_text_metadata.json')))
+
+        self.assertTrue(os.path.isfile(
+            os.path.join(LOCAL_PATH, 'fixtures/record_no_text.txt')))
+        self.assertTrue(os.path.isfile(
+            os.path.join(LOCAL_PATH, 'fixtures/record_no_text_001.png')))
+        self.assertTrue(os.path.isfile(os.path.join(
+            LOCAL_PATH, 'fixtures/record_no_text_metadata.json')))
 
 
 class Testtextextractor(TestCase):
@@ -188,14 +186,14 @@ class Testtextextractor(TestCase):
             self.assertTrue(os.path.isfile(root + '_metadata.json'))
 
         # Check that only doc with no text used OCR
-        self.assertTrue(
-            os.path.isfile(LOCAL_PATH + '/fixtures/record_no_text.png'))
-        self.assertTrue(
-            os.path.isfile(LOCAL_PATH + '/fixtures/record_some_text.png'))
-        self.assertFalse(
-            os.path.isfile(LOCAL_PATH + '/fixtures/record_text.png'))
-        self.assertFalse(
-            os.path.isfile(LOCAL_PATH + '/fixtures/excel_spreadsheet.png'))
+        self.assertTrue(os.path.isfile(
+            os.path.join(LOCAL_PATH, 'fixtures/record_no_text_001.png')))
+        self.assertTrue(os.path.isfile(
+            os.path.join(LOCAL_PATH, 'fixtures/record_some_text_001.png')))
+        self.assertFalse(os.path.isfile(
+            os.path.join(LOCAL_PATH, 'fixtures/record_text_001.png')))
+        self.assertFalse(os.path.isfile(
+            os.path.join(LOCAL_PATH, 'fixtures/excel_spreadsheet_001.png')))
 
 if __name__ == '__main__':
     main()

--- a/textextraction/extractors.py
+++ b/textextraction/extractors.py
@@ -18,10 +18,10 @@ class TextExtraction:
         self.doc_path = doc_path
         self.root, self.extension = os.path.splitext(doc_path)
         self.tika_port = tika_port
-        self.text_arg_str = 'curl -T {0} http://' + host + ':{1}/tika' + \
-            ' -s --header "Accept: text/plain"'
-        self.metadata_arg_str = 'curl -T {0} http://' + host + ':{1}/meta' + \
-            ' -s --header "Accept: application/json" > {2}'
+        self.text_arg_str = 'curl -T {0} http://' + host + ':{1}/tika '
+        self.text_arg_str += '-s --header "Accept: text/plain"'
+        self.metadata_arg_str = 'curl -T {0} http://' + host + ':{1}/meta '
+        self.metadata_arg_str += '-s --header "Accept: application/json" > {2}'
 
     def save_text(self, document):
         """ Reads document text and saves it to specified export path """
@@ -101,29 +101,25 @@ class PDFTextExtraction(TextExtraction):
             return True
 
     def img_to_text(self):
-        """ Uses Tesseract OCR to convert tiff image to text file """
+        """ Uses Tesseract OCR to convert png image to text file """
 
         document = subprocess.Popen(
-            args=['tesseract', self.root + '.tiff', self.root],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT
+            args=['tesseract', self.root + '.png', self.root],
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT
         )
         document.communicate()
-        logging.info("%s converted to text from image", self.root + '.tiff')
+        logging.info("%s converted to text from image", self.root + '.png')
 
     def pdf_to_img(self):
-        """ Converts and saves pdf file to tiff image using Ghostscript"""
+        """ Converts and saves pdf file to png image using Ghostscript"""
 
-        export_path = self.root + ".tiff"
-
-        args = 'gs -dNOPAUSE -dBATCH -sDEVICE=tiffg4 -sOutputFile={0} {1}'
-        args = args.format(export_path, self.doc_path)
+        export_path = self.root + ".png"
+        args = [
+            'gs', '-dNOPAUSE', '-dBATCH', '-sDEVICE=pnggray', '-r300',
+            '-sOutputFile={0}'.format(export_path), self.doc_path
+        ]
         process = subprocess.Popen(
-            args=[args],
-            shell=True,
-            stderr=subprocess.STDOUT,
-            stdout=subprocess.PIPE
-        )
+            args=args, stderr=subprocess.STDOUT, stdout=subprocess.PIPE)
         process.communicate()
         logging.info("%s converted to tiff image", self.doc_path)
         return export_path

--- a/textextraction/extractors.py
+++ b/textextraction/extractors.py
@@ -133,7 +133,7 @@ class PDFTextExtraction(TextExtraction):
         process = subprocess.Popen(
             args=args, stderr=subprocess.STDOUT, stdout=subprocess.PIPE)
         process.communicate()
-        logging.info("%s converted to tiff image", self.doc_path)
+        logging.info("%s converted to png images", self.doc_path)
         return export_path
 
     def extract(self):


### PR DESCRIPTION
I read through the [Freelaw Project Courtlistener's source code](https://github.com/freelawproject/courtlistener) to see how they apply OCR. Courtlistener converts PDFs to greyscale pngs files instead of tiffs with [imagemagick](www.imagemagick.org/). This PR applies those settings, but keeps Ghostscript because it's [faster](http://bertanguven.com/faster-conversions-from-pdf-to-pngjpeg-imagemagick-vs-ghostscript/).

Also updated Ghostscript to run faster and produce better images for Tesseract based on [these suggestions](https://mazira.com/blog/optimal-image-conversion-settings-tesseract-ocr)
The ORC now runs faster and is more accurate. 
#### Without pngs

``` bash
$ nosetests --with-coverage
........
Name                        Stmts   Miss  Cover   Missing
---------------------------------------------------------
textextraction                  0      0   100%   
textextraction.extractors      67      0   100%   
---------------------------------------------------------
TOTAL                          67      0   100%   
----------------------------------------------------------------------
Ran 8 tests in 115.888s

```
#### With pngs

``` bash
Name                        Stmts   Miss  Cover   Missing
---------------------------------------------------------
textextraction                  0      0   100%   
textextraction.extractors      79      0   100%   
---------------------------------------------------------
TOTAL                          79      0   100%   
----------------------------------------------------------------------
Ran 8 tests in 15.249s
```
